### PR TITLE
Remove spinner buttons form TAB focus 

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -12,8 +12,8 @@
 
 <div class="js-spinner"> <!-- js-spinner is an important scoping class for the input controls. -->
     <input type="number" step="4" max="10" min="0" data-stepper-debounce="400" class="js-stepper">
-    <button type="button" spinner-button="up" title="add 1">+</button>
-    <button type="button" spinner-button="down" title="subtract 1">-</button>
+    <button type="button" spinner-button="up" title="add 1" tabindex="-1">+</button>
+    <button type="button" spinner-button="down" title="subtract 1" tabindex="-1">-</button>
 </div>
 
 <script src="./../node_modules/jquery/dist/jquery.slim.min.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ Setting [options](https://github.com/gijsroge/stepper.js#options) is as simple a
 <body>
     <div class="js-spinner">
         <input type="number" step="1" max="10" min="0" data-stepper-debounce="400" class="js-stepper">
-        <button type="button" spinner-button="up" title="add 1">+</button>
-        <button type="button" spinner-button="down" title="subtract 1">-</button>
+        <button type="button" spinner-button="up" title="add 1" tabindex="-1">+</button>
+        <button type="button" spinner-button="down" title="subtract 1" tabindex="-1">-</button>
     </div>
 
     <script src="jquery.js"></script>


### PR DESCRIPTION
As on default `input[type=number]` there is no focus on up/down buttons.
And *stepper.js* also does not support keyboard control on the buttons. So we don't need TAB focus on them.